### PR TITLE
update ORAS annotation param

### DIFF
--- a/.github/workflows/release-content.yaml
+++ b/.github/workflows/release-content.yaml
@@ -55,7 +55,7 @@ jobs:
         SERVER: ${{ steps.config.outputs.server }}
       run: |
        while read -r tag; do
-          oras push "$SERVER/$REPO":$tag --manifest-annotations ./annotations.json bundle.tar.gz
+          oras push "$SERVER/$REPO":$tag --annotation-file ./annotations.json bundle.tar.gz
         done < <(echo "${{ steps.sver.outputs.version }}")
 
     - name: Oras Logout


### PR DESCRIPTION
in Oras v0.14.0. The `--manifest-annotations` parameter was renamed to to `--annotation-file`. This PR updates the oras push command to cover this change.

Ref: https://github.com/oras-project/oras/releases/tag/v0.14.0